### PR TITLE
OLMIS-8191: Wrap Proof of Delivery notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 6.1.10-SNAPSHOT (WIP)
 =================
+* [OLMIS-8191](https://openlmis.atlassian.net/browse/OLMIS-8191): Wrap long Proof of Delivery notes consistently — a growing textarea when editing and a wrapping cell when viewing.
 
 6.1.9 / 2026-06-09
 =================

--- a/src/proof-of-delivery-view/proof-of-delivery-view.html
+++ b/src/proof-of-delivery-view/proof-of-delivery-view.html
@@ -118,10 +118,10 @@
                         {{vm.getReasonName(fulfillingLineItem.rejectionReasonId)}}
                     </td>
                     <td ng-if="vm.canEdit">
-                        <input type="text" ng-model="fulfillingLineItem.notes"/>
+                        <textarea class="openlmis-long-text" ng-model="fulfillingLineItem.notes"></textarea>
                     </td>
                     <td ng-if="!vm.canEdit">
-                        {{fulfillingLineItem.notes}}
+                        <span class="openlmis-long-text">{{fulfillingLineItem.notes}}</span>
                     </td>
                 </tr>
             </tbody>            


### PR DESCRIPTION
## What
Proof of Delivery notes use the shared `openlmis-long-text` class — a growing textarea when editing (was a single-line `<input>`) and a wrapping cell when viewing. No length cap: the notes column is `text` (unbounded).

## Depends on
openlmis-ui-components PR (same branch).

OLMIS-8191
